### PR TITLE
Potential fix for code scanning alert no. 20: Server-side request forgery

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -92,6 +92,10 @@ export async function updateScheduleAction(id: string, formData: FormData) {
 }
 
 export async function deleteScheduleAction(id: string) {
+  // Validate that `id` is a UUID (edit the regex if your ID format differs)
+  if (!/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id)) {
+    throw new Error('Invalid schedule ID');
+  }
   const userId = await requireRole('admin');
 
   const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';


### PR DESCRIPTION
Potential fix for [https://github.com/peteywee/fresh/security/code-scanning/20](https://github.com/peteywee/fresh/security/code-scanning/20)

To fix the issue, we need to ensure that the `id` parameter used in the outgoing API request path is trusted and safe. The best solution is to validate (or sanitize) the `id` variable before using it in the fetch URL. If schedule IDs are UUIDs, we can verify that `id` matches a strict UUID pattern before proceeding. If they are numeric or otherwise constrained, apply a type and pattern check accordingly.

- If `id` does not conform to the expected pattern, throw an error.
- Implement the validation within `deleteScheduleAction` before using `id` in the `fetch` call.
- This restricts possible exploit paths because only valid IDs will be used in URL construction.

No changes to imports or dependencies are required as we can use plain JavaScript Regex for validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
